### PR TITLE
feat: add recetas (prescriptions) domain with complete CRUD

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -33,6 +33,11 @@ func main() {
 	userUseCase := usecases.NewUserUseCase(userService)
 	userHandler := handlers.NewUserHandler(userUseCase)
 
+	recetaRepo := repositories.NewRecetaRepository(db.GetDB())
+	recetaService := services.NewRecetaService(recetaRepo)
+	recetaUseCase := usecases.NewRecetaUseCase(recetaService)
+	recetaHandler := handlers.NewRecetaHandler(recetaUseCase)
+
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 
@@ -53,6 +58,7 @@ func main() {
 	})
 
 	routes.SetupUserRoutes(router, userHandler)
+	routes.SetupRecetaRoutes(router, recetaHandler)
 
 	serverAddr := cfg.Server.Host + ":" + cfg.Server.Port
 	log.Printf("Starting server on %s", serverAddr)

--- a/internal/application/usecases/receta_usecase.go
+++ b/internal/application/usecases/receta_usecase.go
@@ -1,0 +1,95 @@
+package usecases
+
+import (
+	"context"
+
+	"iris-api/internal/domain/entities"
+	"iris-api/internal/domain/services"
+)
+
+type RecetaUseCase interface {
+	CreateReceta(ctx context.Context, req *entities.CreateRecetaRequest) (*entities.Receta, error)
+	GetRecetaByID(ctx context.Context, id int64) (*entities.Receta, error)
+	GetRecetas(ctx context.Context, limit, offset int) (*GetRecetasResponse, error)
+	GetRecetasByPacienteID(ctx context.Context, pacienteID int64, limit, offset int) (*GetRecetasResponse, error)
+	GetHistorialByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error)
+	CheckDioptriasChange(ctx context.Context, pacienteID int64) (*entities.DioptriasChange, error)
+	UpdateReceta(ctx context.Context, id int64, req *entities.UpdateRecetaRequest) (*entities.Receta, error)
+	DeleteReceta(ctx context.Context, id int64) error
+}
+
+type GetRecetasResponse struct {
+	Recetas []*entities.Receta `json:"recetas"`
+	Total   int                `json:"total"`
+	Limit   int                `json:"limit"`
+	Offset  int                `json:"offset"`
+	HasMore bool               `json:"has_more"`
+}
+
+type recetaUseCase struct {
+	recetaService services.RecetaService
+}
+
+func NewRecetaUseCase(recetaService services.RecetaService) RecetaUseCase {
+	return &recetaUseCase{
+		recetaService: recetaService,
+	}
+}
+
+func (uc *recetaUseCase) CreateReceta(ctx context.Context, req *entities.CreateRecetaRequest) (*entities.Receta, error) {
+	return uc.recetaService.CreateReceta(ctx, req)
+}
+
+func (uc *recetaUseCase) GetRecetaByID(ctx context.Context, id int64) (*entities.Receta, error) {
+	return uc.recetaService.GetRecetaByID(ctx, id)
+}
+
+func (uc *recetaUseCase) GetRecetas(ctx context.Context, limit, offset int) (*GetRecetasResponse, error) {
+	recetas, total, err := uc.recetaService.GetRecetas(ctx, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	hasMore := (offset + limit) < total
+
+	return &GetRecetasResponse{
+		Recetas: recetas,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (uc *recetaUseCase) GetRecetasByPacienteID(ctx context.Context, pacienteID int64, limit, offset int) (*GetRecetasResponse, error) {
+	recetas, total, err := uc.recetaService.GetRecetasByPacienteID(ctx, pacienteID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	hasMore := (offset + limit) < total
+
+	return &GetRecetasResponse{
+		Recetas: recetas,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+		HasMore: hasMore,
+	}, nil
+}
+
+func (uc *recetaUseCase) GetHistorialByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error) {
+	return uc.recetaService.GetHistorialByPacienteID(ctx, pacienteID)
+}
+
+func (uc *recetaUseCase) CheckDioptriasChange(ctx context.Context, pacienteID int64) (*entities.DioptriasChange, error) {
+	return uc.recetaService.CheckDioptriasChange(ctx, pacienteID)
+}
+
+func (uc *recetaUseCase) UpdateReceta(ctx context.Context, id int64, req *entities.UpdateRecetaRequest) (*entities.Receta, error) {
+	return uc.recetaService.UpdateReceta(ctx, id, req)
+}
+
+func (uc *recetaUseCase) DeleteReceta(ctx context.Context, id int64) error {
+	return uc.recetaService.DeleteReceta(ctx, id)
+}

--- a/internal/domain/entities/receta.go
+++ b/internal/domain/entities/receta.go
@@ -1,0 +1,53 @@
+package entities
+
+import (
+	"time"
+)
+
+type Receta struct {
+	ID           int64     `json:"id" db:"id"`
+	PacienteID   int64     `json:"paciente_id" db:"paciente_id"`
+	Fecha        time.Time `json:"fecha" db:"fecha"`
+	ODEsfera     float64   `json:"od_esfera" db:"od_esfera"`
+	ODCilindro   float64   `json:"od_cilindro" db:"od_cilindro"`
+	ODEje        int       `json:"od_eje" db:"od_eje"`
+	OIEsfera     float64   `json:"oi_esfera" db:"oi_esfera"`
+	OICilindro   float64   `json:"oi_cilindro" db:"oi_cilindro"`
+	OIEje        int       `json:"oi_eje" db:"oi_eje"`
+	TipoLente    string    `json:"tipo_lente" db:"tipo_lente"`
+	Observaciones string   `json:"observaciones,omitempty" db:"observaciones"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
+}
+
+type CreateRecetaRequest struct {
+	PacienteID    int64     `json:"paciente_id" validate:"required"`
+	Fecha         time.Time `json:"fecha" validate:"required"`
+	ODEsfera      float64   `json:"od_esfera" validate:"required,min=-20,max=20"`
+	ODCilindro    float64   `json:"od_cilindro" validate:"min=-10,max=10"`
+	ODEje         int       `json:"od_eje" validate:"min=0,max=180"`
+	OIEsfera      float64   `json:"oi_esfera" validate:"required,min=-20,max=20"`
+	OICilindro    float64   `json:"oi_cilindro" validate:"min=-10,max=10"`
+	OIEje         int       `json:"oi_eje" validate:"min=0,max=180"`
+	TipoLente     string    `json:"tipo_lente" validate:"required,oneof=monofocal bifocal multifocal progresivo"`
+	Observaciones string    `json:"observaciones,omitempty" validate:"max=500"`
+}
+
+type UpdateRecetaRequest struct {
+	Fecha         *time.Time `json:"fecha,omitempty"`
+	ODEsfera      *float64   `json:"od_esfera,omitempty" validate:"omitempty,min=-20,max=20"`
+	ODCilindro    *float64   `json:"od_cilindro,omitempty" validate:"omitempty,min=-10,max=10"`
+	ODEje         *int       `json:"od_eje,omitempty" validate:"omitempty,min=0,max=180"`
+	OIEsfera      *float64   `json:"oi_esfera,omitempty" validate:"omitempty,min=-20,max=20"`
+	OICilindro    *float64   `json:"oi_cilindro,omitempty" validate:"omitempty,min=-10,max=10"`
+	OIEje         *int       `json:"oi_eje,omitempty" validate:"omitempty,min=0,max=180"`
+	TipoLente     *string    `json:"tipo_lente,omitempty" validate:"omitempty,oneof=monofocal bifocal multifocal progresivo"`
+	Observaciones *string    `json:"observaciones,omitempty" validate:"omitempty,max=500"`
+}
+
+type DioptriasChange struct {
+	ODChange float64 `json:"od_change"`
+	OIChange float64 `json:"oi_change"`
+	HasAlert bool    `json:"has_alert"`
+	Message  string  `json:"message"`
+}

--- a/internal/domain/repositories/receta_repository.go
+++ b/internal/domain/repositories/receta_repository.go
@@ -1,0 +1,20 @@
+package repositories
+
+import (
+	"context"
+
+	"iris-api/internal/domain/entities"
+)
+
+type RecetaRepository interface {
+	Create(ctx context.Context, receta *entities.Receta) (*entities.Receta, error)
+	GetByID(ctx context.Context, id int64) (*entities.Receta, error)
+	GetAll(ctx context.Context, limit, offset int) ([]*entities.Receta, error)
+	GetByPacienteID(ctx context.Context, pacienteID int64, limit, offset int) ([]*entities.Receta, error)
+	GetHistorialByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error)
+	GetLastTwoByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error)
+	Update(ctx context.Context, id int64, receta *entities.Receta) (*entities.Receta, error)
+	Delete(ctx context.Context, id int64) error
+	Count(ctx context.Context) (int, error)
+	CountByPacienteID(ctx context.Context, pacienteID int64) (int, error)
+}

--- a/internal/domain/services/receta_service.go
+++ b/internal/domain/services/receta_service.go
@@ -1,0 +1,263 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"iris-api/internal/domain/entities"
+	"iris-api/internal/domain/repositories"
+)
+
+type RecetaService interface {
+	CreateReceta(ctx context.Context, req *entities.CreateRecetaRequest) (*entities.Receta, error)
+	GetRecetaByID(ctx context.Context, id int64) (*entities.Receta, error)
+	GetRecetas(ctx context.Context, limit, offset int) ([]*entities.Receta, int, error)
+	GetRecetasByPacienteID(ctx context.Context, pacienteID int64, limit, offset int) ([]*entities.Receta, int, error)
+	GetHistorialByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error)
+	CheckDioptriasChange(ctx context.Context, pacienteID int64) (*entities.DioptriasChange, error)
+	UpdateReceta(ctx context.Context, id int64, req *entities.UpdateRecetaRequest) (*entities.Receta, error)
+	DeleteReceta(ctx context.Context, id int64) error
+}
+
+type recetaService struct {
+	recetaRepo repositories.RecetaRepository
+}
+
+func NewRecetaService(recetaRepo repositories.RecetaRepository) RecetaService {
+	return &recetaService{
+		recetaRepo: recetaRepo,
+	}
+}
+
+func (s *recetaService) CreateReceta(ctx context.Context, req *entities.CreateRecetaRequest) (*entities.Receta, error) {
+	if err := s.validateCreateRecetaRequest(req); err != nil {
+		return nil, err
+	}
+
+	receta := &entities.Receta{
+		PacienteID:    req.PacienteID,
+		Fecha:         req.Fecha,
+		ODEsfera:      req.ODEsfera,
+		ODCilindro:    req.ODCilindro,
+		ODEje:         req.ODEje,
+		OIEsfera:      req.OIEsfera,
+		OICilindro:    req.OICilindro,
+		OIEje:         req.OIEje,
+		TipoLente:     req.TipoLente,
+		Observaciones: req.Observaciones,
+	}
+
+	return s.recetaRepo.Create(ctx, receta)
+}
+
+func (s *recetaService) GetRecetaByID(ctx context.Context, id int64) (*entities.Receta, error) {
+	if id <= 0 {
+		return nil, fmt.Errorf("invalid receta ID")
+	}
+
+	return s.recetaRepo.GetByID(ctx, id)
+}
+
+func (s *recetaService) GetRecetas(ctx context.Context, limit, offset int) ([]*entities.Receta, int, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	recetas, err := s.recetaRepo.GetAll(ctx, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	total, err := s.recetaRepo.Count(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return recetas, total, nil
+}
+
+func (s *recetaService) GetRecetasByPacienteID(ctx context.Context, pacienteID int64, limit, offset int) ([]*entities.Receta, int, error) {
+	if pacienteID <= 0 {
+		return nil, 0, fmt.Errorf("invalid paciente ID")
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	recetas, err := s.recetaRepo.GetByPacienteID(ctx, pacienteID, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	total, err := s.recetaRepo.CountByPacienteID(ctx, pacienteID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return recetas, total, nil
+}
+
+func (s *recetaService) GetHistorialByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error) {
+	if pacienteID <= 0 {
+		return nil, fmt.Errorf("invalid paciente ID")
+	}
+
+	return s.recetaRepo.GetHistorialByPacienteID(ctx, pacienteID)
+}
+
+func (s *recetaService) CheckDioptriasChange(ctx context.Context, pacienteID int64) (*entities.DioptriasChange, error) {
+	if pacienteID <= 0 {
+		return nil, fmt.Errorf("invalid paciente ID")
+	}
+
+	recetas, err := s.recetaRepo.GetLastTwoByPacienteID(ctx, pacienteID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(recetas) < 2 {
+		return &entities.DioptriasChange{
+			ODChange: 0,
+			OIChange: 0,
+			HasAlert: false,
+			Message:  "No hay suficientes recetas para comparar",
+		}, nil
+	}
+
+	// recetas[0] es la más reciente, recetas[1] es la anterior
+	latest := recetas[0]
+	previous := recetas[1]
+
+	odChange := math.Abs(latest.ODEsfera - previous.ODEsfera)
+	oiChange := math.Abs(latest.OIEsfera - previous.OIEsfera)
+
+	hasAlert := odChange > 0.25 || oiChange > 0.25
+
+	message := "Sin cambios significativos"
+	if hasAlert {
+		message = fmt.Sprintf("⚠️ Cambio significativo detectado: OD %.2fD, OI %.2fD", odChange, oiChange)
+	}
+
+	return &entities.DioptriasChange{
+		ODChange: odChange,
+		OIChange: oiChange,
+		HasAlert: hasAlert,
+		Message:  message,
+	}, nil
+}
+
+func (s *recetaService) UpdateReceta(ctx context.Context, id int64, req *entities.UpdateRecetaRequest) (*entities.Receta, error) {
+	if id <= 0 {
+		return nil, fmt.Errorf("invalid receta ID")
+	}
+
+	if err := s.validateUpdateRecetaRequest(req); err != nil {
+		return nil, err
+	}
+
+	existingReceta, err := s.recetaRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Fecha != nil {
+		existingReceta.Fecha = *req.Fecha
+	}
+	if req.ODEsfera != nil {
+		existingReceta.ODEsfera = *req.ODEsfera
+	}
+	if req.ODCilindro != nil {
+		existingReceta.ODCilindro = *req.ODCilindro
+	}
+	if req.ODEje != nil {
+		existingReceta.ODEje = *req.ODEje
+	}
+	if req.OIEsfera != nil {
+		existingReceta.OIEsfera = *req.OIEsfera
+	}
+	if req.OICilindro != nil {
+		existingReceta.OICilindro = *req.OICilindro
+	}
+	if req.OIEje != nil {
+		existingReceta.OIEje = *req.OIEje
+	}
+	if req.TipoLente != nil {
+		existingReceta.TipoLente = *req.TipoLente
+	}
+	if req.Observaciones != nil {
+		existingReceta.Observaciones = *req.Observaciones
+	}
+
+	return s.recetaRepo.Update(ctx, id, existingReceta)
+}
+
+func (s *recetaService) DeleteReceta(ctx context.Context, id int64) error {
+	if id <= 0 {
+		return fmt.Errorf("invalid receta ID")
+	}
+
+	return s.recetaRepo.Delete(ctx, id)
+}
+
+func (s *recetaService) validateCreateRecetaRequest(req *entities.CreateRecetaRequest) error {
+	if req.PacienteID <= 0 {
+		return fmt.Errorf("paciente_id is required")
+	}
+	if req.Fecha.IsZero() {
+		return fmt.Errorf("fecha is required")
+	}
+	if req.ODEsfera < -20 || req.ODEsfera > 20 {
+		return fmt.Errorf("od_esfera must be between -20 and 20")
+	}
+	if req.OIEsfera < -20 || req.OIEsfera > 20 {
+		return fmt.Errorf("oi_esfera must be between -20 and 20")
+	}
+	if req.TipoLente == "" {
+		return fmt.Errorf("tipo_lente is required")
+	}
+	validTipos := map[string]bool{
+		"monofocal":  true,
+		"bifocal":    true,
+		"multifocal": true,
+		"progresivo": true,
+	}
+	if !validTipos[req.TipoLente] {
+		return fmt.Errorf("tipo_lente must be one of: monofocal, bifocal, multifocal, progresivo")
+	}
+	return nil
+}
+
+func (s *recetaService) validateUpdateRecetaRequest(req *entities.UpdateRecetaRequest) error {
+	if req.ODEsfera != nil && (*req.ODEsfera < -20 || *req.ODEsfera > 20) {
+		return fmt.Errorf("od_esfera must be between -20 and 20")
+	}
+	if req.OIEsfera != nil && (*req.OIEsfera < -20 || *req.OIEsfera > 20) {
+		return fmt.Errorf("oi_esfera must be between -20 and 20")
+	}
+	if req.TipoLente != nil {
+		validTipos := map[string]bool{
+			"monofocal":  true,
+			"bifocal":    true,
+			"multifocal": true,
+			"progresivo": true,
+		}
+		if !validTipos[*req.TipoLente] {
+			return fmt.Errorf("tipo_lente must be one of: monofocal, bifocal, multifocal, progresivo")
+		}
+	}
+	return nil
+}

--- a/internal/infrastructure/repositories/receta_repository.go
+++ b/internal/infrastructure/repositories/receta_repository.go
@@ -1,0 +1,254 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"iris-api/internal/domain/entities"
+	"iris-api/internal/domain/repositories"
+)
+
+type recetaRepository struct {
+	db *sqlx.DB
+}
+
+func NewRecetaRepository(db *sqlx.DB) repositories.RecetaRepository {
+	return &recetaRepository{db: db}
+}
+
+func (r *recetaRepository) Create(ctx context.Context, receta *entities.Receta) (*entities.Receta, error) {
+	query := `
+		INSERT INTO recetas (paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+	`
+
+	now := time.Now()
+	receta.CreatedAt = now
+	receta.UpdatedAt = now
+
+	row := r.db.QueryRowContext(ctx, query,
+		receta.PacienteID,
+		receta.Fecha,
+		receta.ODEsfera,
+		receta.ODCilindro,
+		receta.ODEje,
+		receta.OIEsfera,
+		receta.OICilindro,
+		receta.OIEje,
+		receta.TipoLente,
+		receta.Observaciones,
+		receta.CreatedAt,
+		receta.UpdatedAt,
+	)
+
+	var createdReceta entities.Receta
+	err := row.Scan(
+		&createdReceta.ID,
+		&createdReceta.PacienteID,
+		&createdReceta.Fecha,
+		&createdReceta.ODEsfera,
+		&createdReceta.ODCilindro,
+		&createdReceta.ODEje,
+		&createdReceta.OIEsfera,
+		&createdReceta.OICilindro,
+		&createdReceta.OIEje,
+		&createdReceta.TipoLente,
+		&createdReceta.Observaciones,
+		&createdReceta.CreatedAt,
+		&createdReceta.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create receta: %w", err)
+	}
+
+	return &createdReceta, nil
+}
+
+func (r *recetaRepository) GetByID(ctx context.Context, id int64) (*entities.Receta, error) {
+	query := `
+		SELECT id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+		FROM recetas
+		WHERE id = $1
+	`
+
+	var receta entities.Receta
+	err := r.db.GetContext(ctx, &receta, query, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("receta not found")
+		}
+		return nil, fmt.Errorf("failed to get receta: %w", err)
+	}
+
+	return &receta, nil
+}
+
+func (r *recetaRepository) GetAll(ctx context.Context, limit, offset int) ([]*entities.Receta, error) {
+	query := `
+		SELECT id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+		FROM recetas
+		ORDER BY fecha DESC, created_at DESC
+		LIMIT $1 OFFSET $2
+	`
+
+	var recetas []*entities.Receta
+	err := r.db.SelectContext(ctx, &recetas, query, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recetas: %w", err)
+	}
+
+	return recetas, nil
+}
+
+func (r *recetaRepository) GetByPacienteID(ctx context.Context, pacienteID int64, limit, offset int) ([]*entities.Receta, error) {
+	query := `
+		SELECT id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+		FROM recetas
+		WHERE paciente_id = $1
+		ORDER BY fecha DESC, created_at DESC
+		LIMIT $2 OFFSET $3
+	`
+
+	var recetas []*entities.Receta
+	err := r.db.SelectContext(ctx, &recetas, query, pacienteID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recetas for paciente: %w", err)
+	}
+
+	return recetas, nil
+}
+
+func (r *recetaRepository) GetHistorialByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error) {
+	query := `
+		SELECT id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+		FROM recetas
+		WHERE paciente_id = $1
+		ORDER BY fecha DESC, created_at DESC
+	`
+
+	var recetas []*entities.Receta
+	err := r.db.SelectContext(ctx, &recetas, query, pacienteID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get historial for paciente: %w", err)
+	}
+
+	return recetas, nil
+}
+
+func (r *recetaRepository) GetLastTwoByPacienteID(ctx context.Context, pacienteID int64) ([]*entities.Receta, error) {
+	query := `
+		SELECT id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+		FROM recetas
+		WHERE paciente_id = $1
+		ORDER BY fecha DESC, created_at DESC
+		LIMIT 2
+	`
+
+	var recetas []*entities.Receta
+	err := r.db.SelectContext(ctx, &recetas, query, pacienteID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last two recetas for paciente: %w", err)
+	}
+
+	return recetas, nil
+}
+
+func (r *recetaRepository) Update(ctx context.Context, id int64, receta *entities.Receta) (*entities.Receta, error) {
+	query := `
+		UPDATE recetas
+		SET paciente_id = $1, fecha = $2, od_esfera = $3, od_cilindro = $4, od_eje = $5, oi_esfera = $6, oi_cilindro = $7, oi_eje = $8, tipo_lente = $9, observaciones = $10, updated_at = $11
+		WHERE id = $12
+		RETURNING id, paciente_id, fecha, od_esfera, od_cilindro, od_eje, oi_esfera, oi_cilindro, oi_eje, tipo_lente, observaciones, created_at, updated_at
+	`
+
+	receta.UpdatedAt = time.Now()
+
+	row := r.db.QueryRowContext(ctx, query,
+		receta.PacienteID,
+		receta.Fecha,
+		receta.ODEsfera,
+		receta.ODCilindro,
+		receta.ODEje,
+		receta.OIEsfera,
+		receta.OICilindro,
+		receta.OIEje,
+		receta.TipoLente,
+		receta.Observaciones,
+		receta.UpdatedAt,
+		id,
+	)
+
+	var updatedReceta entities.Receta
+	err := row.Scan(
+		&updatedReceta.ID,
+		&updatedReceta.PacienteID,
+		&updatedReceta.Fecha,
+		&updatedReceta.ODEsfera,
+		&updatedReceta.ODCilindro,
+		&updatedReceta.ODEje,
+		&updatedReceta.OIEsfera,
+		&updatedReceta.OICilindro,
+		&updatedReceta.OIEje,
+		&updatedReceta.TipoLente,
+		&updatedReceta.Observaciones,
+		&updatedReceta.CreatedAt,
+		&updatedReceta.UpdatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("receta not found")
+		}
+		return nil, fmt.Errorf("failed to update receta: %w", err)
+	}
+
+	return &updatedReceta, nil
+}
+
+func (r *recetaRepository) Delete(ctx context.Context, id int64) error {
+	query := `DELETE FROM recetas WHERE id = $1`
+
+	result, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete receta: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("receta not found")
+	}
+
+	return nil
+}
+
+func (r *recetaRepository) Count(ctx context.Context) (int, error) {
+	query := `SELECT COUNT(*) FROM recetas`
+
+	var count int
+	err := r.db.GetContext(ctx, &count, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count recetas: %w", err)
+	}
+
+	return count, nil
+}
+
+func (r *recetaRepository) CountByPacienteID(ctx context.Context, pacienteID int64) (int, error) {
+	query := `SELECT COUNT(*) FROM recetas WHERE paciente_id = $1`
+
+	var count int
+	err := r.db.GetContext(ctx, &count, query, pacienteID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count recetas for paciente: %w", err)
+	}
+
+	return count, nil
+}

--- a/internal/presentation/handlers/receta_handler.go
+++ b/internal/presentation/handlers/receta_handler.go
@@ -1,0 +1,250 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"iris-api/internal/application/usecases"
+	"iris-api/internal/domain/entities"
+)
+
+type RecetaHandler struct {
+	recetaUseCase usecases.RecetaUseCase
+}
+
+func NewRecetaHandler(recetaUseCase usecases.RecetaUseCase) *RecetaHandler {
+	return &RecetaHandler{
+		recetaUseCase: recetaUseCase,
+	}
+}
+
+func (h *RecetaHandler) CreateReceta(c *gin.Context) {
+	var req entities.CreateRecetaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	receta, err := h.recetaUseCase.CreateReceta(c.Request.Context(), &req)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Failed to create receta",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "Receta created successfully",
+		"data":    receta,
+	})
+}
+
+func (h *RecetaHandler) GetRecetaByID(c *gin.Context) {
+	idParam := c.Param("id")
+	id, err := strconv.ParseInt(idParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid receta ID",
+			"details": "Receta ID must be a number",
+		})
+		return
+	}
+
+	receta, err := h.recetaUseCase.GetRecetaByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "Receta not found",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Receta retrieved successfully",
+		"data":    receta,
+	})
+}
+
+func (h *RecetaHandler) GetRecetas(c *gin.Context) {
+	limitParam := c.DefaultQuery("limit", "10")
+	offsetParam := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitParam)
+	if err != nil || limit <= 0 {
+		limit = 10
+	}
+
+	offset, err := strconv.Atoi(offsetParam)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	response, err := h.recetaUseCase.GetRecetas(c.Request.Context(), limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to retrieve recetas",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Recetas retrieved successfully",
+		"data":    response,
+	})
+}
+
+func (h *RecetaHandler) GetRecetasByPacienteID(c *gin.Context) {
+	pacienteIDParam := c.Param("paciente_id")
+	pacienteID, err := strconv.ParseInt(pacienteIDParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid paciente ID",
+			"details": "Paciente ID must be a number",
+		})
+		return
+	}
+
+	limitParam := c.DefaultQuery("limit", "10")
+	offsetParam := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitParam)
+	if err != nil || limit <= 0 {
+		limit = 10
+	}
+
+	offset, err := strconv.Atoi(offsetParam)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	response, err := h.recetaUseCase.GetRecetasByPacienteID(c.Request.Context(), pacienteID, limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to retrieve recetas for paciente",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Recetas retrieved successfully",
+		"data":    response,
+	})
+}
+
+func (h *RecetaHandler) GetHistorialByPacienteID(c *gin.Context) {
+	pacienteIDParam := c.Param("paciente_id")
+	pacienteID, err := strconv.ParseInt(pacienteIDParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid paciente ID",
+			"details": "Paciente ID must be a number",
+		})
+		return
+	}
+
+	recetas, err := h.recetaUseCase.GetHistorialByPacienteID(c.Request.Context(), pacienteID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to retrieve historial",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Historial retrieved successfully",
+		"data":    recetas,
+	})
+}
+
+func (h *RecetaHandler) CheckDioptriasChange(c *gin.Context) {
+	pacienteIDParam := c.Param("paciente_id")
+	pacienteID, err := strconv.ParseInt(pacienteIDParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid paciente ID",
+			"details": "Paciente ID must be a number",
+		})
+		return
+	}
+
+	change, err := h.recetaUseCase.CheckDioptriasChange(c.Request.Context(), pacienteID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to check dioptrias change",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Dioptrias change checked successfully",
+		"data":    change,
+	})
+}
+
+func (h *RecetaHandler) UpdateReceta(c *gin.Context) {
+	idParam := c.Param("id")
+	id, err := strconv.ParseInt(idParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid receta ID",
+			"details": "Receta ID must be a number",
+		})
+		return
+	}
+
+	var req entities.UpdateRecetaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	receta, err := h.recetaUseCase.UpdateReceta(c.Request.Context(), id, &req)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Failed to update receta",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Receta updated successfully",
+		"data":    receta,
+	})
+}
+
+func (h *RecetaHandler) DeleteReceta(c *gin.Context) {
+	idParam := c.Param("id")
+	id, err := strconv.ParseInt(idParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "Invalid receta ID",
+			"details": "Receta ID must be a number",
+		})
+		return
+	}
+
+	err = h.recetaUseCase.DeleteReceta(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":   "Failed to delete receta",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/internal/presentation/routes/receta_routes.go
+++ b/internal/presentation/routes/receta_routes.go
@@ -1,0 +1,30 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"iris-api/internal/presentation/handlers"
+)
+
+func SetupRecetaRoutes(router *gin.Engine, recetaHandler *handlers.RecetaHandler) {
+	api := router.Group("/api/v1")
+	{
+		recetas := api.Group("/recetas")
+		{
+			// CRUD básico
+			recetas.POST("/", recetaHandler.CreateReceta)
+			recetas.GET("/", recetaHandler.GetRecetas)
+			recetas.GET("/:id", recetaHandler.GetRecetaByID)
+			recetas.PUT("/:id", recetaHandler.UpdateReceta)
+			recetas.DELETE("/:id", recetaHandler.DeleteReceta)
+		}
+
+		// Endpoints específicos por paciente
+		pacientes := api.Group("/pacientes")
+		{
+			pacientes.GET("/:paciente_id/recetas", recetaHandler.GetRecetasByPacienteID)
+			pacientes.GET("/:paciente_id/recetas/historial", recetaHandler.GetHistorialByPacienteID)
+			pacientes.GET("/:paciente_id/recetas/alertas", recetaHandler.CheckDioptriasChange)
+		}
+	}
+}

--- a/migrations/002_create_recetas_table.down.sql
+++ b/migrations/002_create_recetas_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS recetas;

--- a/migrations/002_create_recetas_table.up.sql
+++ b/migrations/002_create_recetas_table.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS recetas (
+    id BIGSERIAL PRIMARY KEY,
+    paciente_id BIGINT NOT NULL,
+    fecha TIMESTAMP NOT NULL,
+    od_esfera DECIMAL(4,2) NOT NULL,
+    od_cilindro DECIMAL(4,2) DEFAULT 0,
+    od_eje INTEGER DEFAULT 0,
+    oi_esfera DECIMAL(4,2) NOT NULL,
+    oi_cilindro DECIMAL(4,2) DEFAULT 0,
+    oi_eje INTEGER DEFAULT 0,
+    tipo_lente VARCHAR(50) NOT NULL,
+    observaciones TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_paciente FOREIGN KEY (paciente_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_recetas_paciente_id ON recetas(paciente_id);
+CREATE INDEX idx_recetas_fecha ON recetas(fecha DESC);


### PR DESCRIPTION
## Summary
- Implement prescription (recetas) management system following Clean Architecture
- Complete CRUD operations for optical prescriptions
- Patient prescription history and tracking
- Diopter change alerts for monitoring vision changes

## Features Added
- **Domain Layer**: Receta entity with validation rules and repository interface
- **Application Layer**: RecetaUseCase with business logic
- **Infrastructure Layer**: PostgreSQL repository implementation with SQLx
- **Presentation Layer**: REST API handlers and routes
- **Database**: Migration for recetas table with patient foreign key relationship
- **Endpoints**: 
  - CRUD operations for prescriptions
  - Patient prescription history
  - Diopter change monitoring and alerts

## Technical Details
- Follows existing Clean Architecture patterns
- Includes comprehensive validation for optical measurements
- Database indexes for optimal query performance
- Foreign key constraint to users (pacientes) table

## Test Plan
- [ ] Run database migrations successfully
- [ ] Test CRUD endpoints for recetas
- [ ] Verify patient-specific endpoints
- [ ] Test diopter change calculation
- [ ] Validate foreign key constraints
- [ ] Check pagination functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)