### PR TITLE
feat: add reporteria module with patient activity reports

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -55,6 +55,12 @@ func main() {
 	authHandler := handlers.NewAuthHandler(authUseCase)
 	authMiddleware := middleware.NewAuthMiddleware(authUseCase)
 
+	// Reporteria setup
+	reporteriaRepo := repositories.NewReporteriaRepository(db.GetDB())
+	reporteriaService := services.NewReporteriaService(reporteriaRepo)
+	reporteriaUseCase := usecases.NewReporteriaUseCase(reporteriaService)
+	reporteriaHandler := handlers.NewReporteriaHandler(reporteriaUseCase)
+
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 
@@ -82,6 +88,7 @@ func main() {
 	routes.SetupUserRoutes(router, userHandler)
 	routes.SetupRecetaRoutes(router, recetaHandler)
 	routes.SetupTurnoRoutes(router, turnoHandler)
+	routes.SetupReporteriaRoutes(router, reporteriaHandler, authMiddleware)
 
 	serverAddr := cfg.Server.Host + ":" + cfg.Server.Port
 	log.Printf("Starting server on %s", serverAddr)

--- a/internal/application/usecases/reporteria_usecase.go
+++ b/internal/application/usecases/reporteria_usecase.go
@@ -1,0 +1,26 @@
+package usecases
+
+import (
+	"context"
+
+	"iris-api/internal/domain/entities"
+	"iris-api/internal/domain/services"
+)
+
+type ReporteriaUseCase struct {
+	reporteriaService *services.ReporteriaService
+}
+
+func NewReporteriaUseCase(reporteriaService *services.ReporteriaService) *ReporteriaUseCase {
+	return &ReporteriaUseCase{
+		reporteriaService: reporteriaService,
+	}
+}
+
+func (uc *ReporteriaUseCase) GetPacientesActivos(ctx context.Context, clientID int64) (*entities.ReportePacientesActivos, error) {
+	return uc.reporteriaService.GetPacientesActivos(ctx, clientID)
+}
+
+func (uc *ReporteriaUseCase) GetPacientesInactivos(ctx context.Context, clientID int64) (*entities.ReportePacientesInactivos, error) {
+	return uc.reporteriaService.GetPacientesInactivos(ctx, clientID)
+}

--- a/internal/domain/entities/reporteria.go
+++ b/internal/domain/entities/reporteria.go
@@ -1,0 +1,30 @@
+package entities
+
+import "time"
+
+type PacienteActivo struct {
+	ID               int64     `json:"id" db:"id"`
+	Name             string    `json:"name" db:"name"`
+	Email            string    `json:"email" db:"email"`
+	UltimoTurno      time.Time `json:"ultimo_turno" db:"ultimo_turno"`
+	TotalTurnos      int       `json:"total_turnos" db:"total_turnos"`
+	TurnosPendientes int       `json:"turnos_pendientes" db:"turnos_pendientes"`
+}
+
+type PacienteInactivo struct {
+	ID          int64     `json:"id" db:"id"`
+	Name        string    `json:"name" db:"name"`
+	Email       string    `json:"email" db:"email"`
+	UltimoTurno time.Time `json:"ultimo_turno" db:"ultimo_turno"`
+	DiasInactivo int      `json:"dias_inactivo" db:"dias_inactivo"`
+}
+
+type ReportePacientesActivos struct {
+	Pacientes []*PacienteActivo `json:"pacientes"`
+	Total     int               `json:"total"`
+}
+
+type ReportePacientesInactivos struct {
+	Pacientes []*PacienteInactivo `json:"pacientes"`
+	Total     int                 `json:"total"`
+}

--- a/internal/domain/repositories/reporteria_repository.go
+++ b/internal/domain/repositories/reporteria_repository.go
@@ -1,0 +1,12 @@
+package repositories
+
+import (
+	"context"
+
+	"iris-api/internal/domain/entities"
+)
+
+type ReporteriaRepository interface {
+	GetPacientesActivos(ctx context.Context, clientID int64) ([]*entities.PacienteActivo, error)
+	GetPacientesInactivos(ctx context.Context, clientID int64, diasInactividad int) ([]*entities.PacienteInactivo, error)
+}

--- a/internal/domain/services/reporteria_service.go
+++ b/internal/domain/services/reporteria_service.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"context"
+
+	"iris-api/internal/domain/entities"
+	"iris-api/internal/domain/repositories"
+)
+
+type ReporteriaService struct {
+	reporteriaRepo repositories.ReporteriaRepository
+}
+
+func NewReporteriaService(reporteriaRepo repositories.ReporteriaRepository) *ReporteriaService {
+	return &ReporteriaService{
+		reporteriaRepo: reporteriaRepo,
+	}
+}
+
+func (s *ReporteriaService) GetPacientesActivos(ctx context.Context, clientID int64) (*entities.ReportePacientesActivos, error) {
+	pacientes, err := s.reporteriaRepo.GetPacientesActivos(ctx, clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entities.ReportePacientesActivos{
+		Pacientes: pacientes,
+		Total:     len(pacientes),
+	}, nil
+}
+
+func (s *ReporteriaService) GetPacientesInactivos(ctx context.Context, clientID int64) (*entities.ReportePacientesInactivos, error) {
+	// 60 días = 2 meses aproximadamente
+	diasInactividad := 60
+
+	pacientes, err := s.reporteriaRepo.GetPacientesInactivos(ctx, clientID, diasInactividad)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entities.ReportePacientesInactivos{
+		Pacientes: pacientes,
+		Total:     len(pacientes),
+	}, nil
+}

--- a/internal/infrastructure/repositories/reporteria_repository.go
+++ b/internal/infrastructure/repositories/reporteria_repository.go
@@ -1,0 +1,70 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"iris-api/internal/domain/entities"
+)
+
+type reporteriaRepository struct {
+	db *sqlx.DB
+}
+
+func NewReporteriaRepository(db *sqlx.DB) *reporteriaRepository {
+	return &reporteriaRepository{db: db}
+}
+
+func (r *reporteriaRepository) GetPacientesActivos(ctx context.Context, clientID int64) ([]*entities.PacienteActivo, error) {
+	query := `
+		SELECT
+			u.id,
+			u.name,
+			u.email,
+			MAX(t.fecha_hora) as ultimo_turno,
+			COUNT(t.id) as total_turnos,
+			COUNT(CASE WHEN t.estado = 'pendiente' OR t.estado = 'confirmado' THEN 1 END) as turnos_pendientes
+		FROM users u
+		INNER JOIN turnos t ON u.id = t.paciente_id
+		WHERE u.client_id = $1
+		  AND t.client_id = $1
+		  AND t.fecha_hora >= NOW() - INTERVAL '60 days'
+		GROUP BY u.id, u.name, u.email
+		ORDER BY ultimo_turno DESC
+	`
+
+	var pacientes []*entities.PacienteActivo
+	err := r.db.SelectContext(ctx, &pacientes, query, clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return pacientes, nil
+}
+
+func (r *reporteriaRepository) GetPacientesInactivos(ctx context.Context, clientID int64, diasInactividad int) ([]*entities.PacienteInactivo, error) {
+	query := `
+		SELECT
+			u.id,
+			u.name,
+			u.email,
+			MAX(t.fecha_hora) as ultimo_turno,
+			EXTRACT(DAY FROM (NOW() - MAX(t.fecha_hora)))::int as dias_inactivo
+		FROM users u
+		INNER JOIN turnos t ON u.id = t.paciente_id
+		WHERE u.client_id = $1
+		  AND t.client_id = $1
+		GROUP BY u.id, u.name, u.email
+		HAVING MAX(t.fecha_hora) < NOW() - INTERVAL '1 day' * $2
+		ORDER BY dias_inactivo DESC
+	`
+
+	var pacientes []*entities.PacienteInactivo
+	err := r.db.SelectContext(ctx, &pacientes, query, clientID, diasInactividad)
+	if err != nil {
+		return nil, err
+	}
+
+	return pacientes, nil
+}

--- a/internal/presentation/handlers/reporteria_handler.go
+++ b/internal/presentation/handlers/reporteria_handler.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"iris-api/internal/application/usecases"
+	"iris-api/internal/presentation/middleware"
+)
+
+type ReporteriaHandler struct {
+	reporteriaUseCase *usecases.ReporteriaUseCase
+}
+
+func NewReporteriaHandler(reporteriaUseCase *usecases.ReporteriaUseCase) *ReporteriaHandler {
+	return &ReporteriaHandler{
+		reporteriaUseCase: reporteriaUseCase,
+	}
+}
+
+func (h *ReporteriaHandler) GetPacientesActivos(c *gin.Context) {
+	// Get client_id from authenticated user context
+	clientID, exists := middleware.GetClientID(c)
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "Client ID not found in context",
+		})
+		return
+	}
+
+	reporte, err := h.reporteriaUseCase.GetPacientesActivos(c.Request.Context(), clientID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to retrieve active patients report",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Active patients report retrieved successfully",
+		"data":    reporte,
+	})
+}
+
+func (h *ReporteriaHandler) GetPacientesInactivos(c *gin.Context) {
+	// Get client_id from authenticated user context
+	clientID, exists := middleware.GetClientID(c)
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "Client ID not found in context",
+		})
+		return
+	}
+
+	reporte, err := h.reporteriaUseCase.GetPacientesInactivos(c.Request.Context(), clientID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "Failed to retrieve inactive patients report",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Inactive patients report retrieved successfully",
+		"data":    reporte,
+	})
+}

--- a/internal/presentation/routes/reporteria_routes.go
+++ b/internal/presentation/routes/reporteria_routes.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"iris-api/internal/domain/entities"
+	"iris-api/internal/presentation/handlers"
+	"iris-api/internal/presentation/middleware"
+)
+
+func SetupReporteriaRoutes(router *gin.Engine, reporteriaHandler *handlers.ReporteriaHandler, authMiddleware *middleware.AuthMiddleware) {
+	api := router.Group("/api/v1")
+	{
+		reportes := api.Group("/reportes")
+		// Require authentication for all reports
+		reportes.Use(authMiddleware.RequireAuth())
+		// Only admin and optometrista can access reports
+		reportes.Use(authMiddleware.RequireRole(entities.RoleAdmin, entities.RoleOptometrista))
+		{
+			reportes.GET("/pacientes-activos", reporteriaHandler.GetPacientesActivos)
+			reportes.GET("/pacientes-inactivos", reporteriaHandler.GetPacientesInactivos)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add reporteria (reports) module with patient activity tracking
- Two endpoints: active patients and inactive patients
- Protected routes with authentication and role-based access

## Features
- **Active Patients Report**: Lists patients with appointments in the last 60 days
- **Inactive Patients Report**: Lists patients without appointments in 60+ days
- Both reports filtered by authenticated user's client_id for tenant isolation
- Routes protected by RequireAuth and RequireRole middleware (admin and optometrista only)

## Implementation Details
- Created entities: ReportePacientesActivos, ReportePacientesInactivos
- Repository with SQL queries using JOINs and date filtering
- Service layer with 60-day inactivity threshold
- Protected routes: `/api/v1/reportes/pacientes-activos` and `/api/v1/reportes/pacientes-inactivos`

## Test plan
- [ ] Test GET /api/v1/reportes/pacientes-activos with authenticated admin user
- [ ] Test GET /api/v1/reportes/pacientes-inactivos with authenticated optometrista user
- [ ] Verify client_id filtering works correctly
- [ ] Verify unauthenticated requests are rejected
- [ ] Verify users without admin/optometrista role are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)